### PR TITLE
Refactor autosave logic to use component-based approach

### DIFF
--- a/Content.Server/Mapping/MappingComponent.cs
+++ b/Content.Server/Mapping/MappingComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+using Robust.Shared.Serialization;
+
+namespace Content.Server.Mapping;
+
+[RegisterComponent]
+public sealed partial class AutoSaveMapComponent : Component
+{
+    [DataField] public TimeSpan NextSaveTime;
+    [DataField] public string FileName = string.Empty;
+}


### PR DESCRIPTION
Replaces the autosave tracking dictionary in MappingSystem with a new AutoSaveMapComponent, improving modularity and ECS compliance. Autosave logic now queries entities with the component, and toggling autosave adds or removes the component as needed. This change simplifies state management and prepares for future extensibility.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
